### PR TITLE
Update README.md with better Regex

### DIFF
--- a/mitigation/README.md
+++ b/mitigation/README.md
@@ -10,7 +10,7 @@ However NCSC-NL strives to provide rules and detection software from reliable so
 Overall detection regex
 
 ```plain
-\${(\${(.*?:|.*?:.*?:-)('|"|`)*(?1)}*|[jndi:lapsrm]('|"|`)*}*){9,11}
+(\$|%24)(\{|%37B).*j.*n.*d.*i.*(:|%3A).+
 ```
 
 ## Closed source intelligence


### PR DESCRIPTION
The regex currently used seems to be unreliable. This one should be better, although I am not 100% sure. It might not be a bad idea to include them both

Source:
https://stackoverflow.com/questions/70307788/regex-to-match-domains-in-log4j-cve-2021-44228-attempts